### PR TITLE
Allow grant on table and sequences to specified role during schema creation

### DIFF
--- a/db_adapter/db/backends/oracle/constants.py
+++ b/db_adapter/db/backends/oracle/constants.py
@@ -39,8 +39,8 @@ CREATE INDEX %(name)s
 '''
 
 SQL_GRANT = '''\
-GRANT %(commands)s
-    ON %(object)s
+GRANT %(privileges)s
+    ON %(name)s
     TO %(role)s\
 '''
 

--- a/db_adapter/db/backends/oracle/operations.py
+++ b/db_adapter/db/backends/oracle/operations.py
@@ -7,6 +7,7 @@ from . import constants
 class DatabaseOperations(DatabaseOperations, oracle.DatabaseOperations):
     sql_create_sequence = constants.SQL_CREATE_SEQUENCE
     sql_create_trigger = constants.SQL_CREATE_TRIGGER
+    sql_grant = constants.SQL_GRANT
 
     integer_field_ranges = {
         **oracle.DatabaseOperations.integer_field_ranges,

--- a/db_adapter/models.py
+++ b/db_adapter/models.py
@@ -1,4 +1,5 @@
 from django.db.models import Model
+from django.db.models.signals import class_prepared, pre_init
 
 from .utils import normalize_table
 
@@ -19,3 +20,7 @@ def apply_db_table_normalization(sender: Model, **kwargs):
         )
 
         sender._meta.db_table = normalized_name
+
+
+pre_init.connect(apply_db_table_normalization)
+class_prepared.connect(apply_db_table_normalization)

--- a/db_adapter/settings.py
+++ b/db_adapter/settings.py
@@ -36,8 +36,17 @@ DEFAULTS = {
     'DEFAULT_UNIQUE_NAME': '{table}_{columns}_uniq',
     'DEFAULT_CHECK_NAME': '{table}_{columns}{qualifier}_check',
 
+    # Grant options
+    'DEFAULT_ROLE_NAME': '',
+
     # Base policies
     'DEFAULT_NAME_BUILDER_CLASS': 'db_adapter.name_builders.ObjectNameBuilder',
+    'DEFAULT_OBJECT_PRIVILEGES': [
+        'SELECT',
+        'INSERT',
+        'UPDATE',
+        'DELETE',
+    ]
 }
 # fmt: on
 

--- a/tests/connection.py
+++ b/tests/connection.py
@@ -20,7 +20,7 @@ class TestDatabaseOperations(DatabaseOperations, DjangoDatabaseOperations):
         return name
 
 
-class TestDatabaseOperationsWithSqls(TestDatabaseOperations):
+class TestDatabaseOperationsAutoincSql(TestDatabaseOperations):
     integer_field_ranges = {
         'SmallIntegerField': (-99999999999, 99999999999),
         'IntegerField': (-99999999999, 99999999999),
@@ -52,7 +52,11 @@ WHEN (new.%(col_name)s IS NULL)
 '''
 
 
-class TestDatabaseOperationsOptionalRange(TestDatabaseOperationsWithSqls):
+class TestDatabaseOperationsControlSql(TestDatabaseOperationsAutoincSql):
+    role_name = 'rl_tests'
+
+
+class TestDatabaseOperationsOptionalRange(TestDatabaseOperationsAutoincSql):
     sql_create_sequence = '''
 DECLARE
     i INTEGER;
@@ -71,7 +75,7 @@ class TestDatabaseSchemaEditor(DatabaseSchemaEditor, BaseDatabaseSchemaEditor):
 
 
 class TestDatabaseWrapper(DatabaseWrapper):
-    ops_class = TestDatabaseOperationsWithSqls
+    ops_class = TestDatabaseOperationsAutoincSql
     SchemaEditorClass = TestDatabaseSchemaEditor
 
     data_types = {
@@ -119,4 +123,9 @@ class TestDatabaseWrapper(DatabaseWrapper):
     }
 
 
-test_connection = TestDatabaseWrapper(settings_dict={}, alias=DEFAULT_DB_ALIAS)
+class TestDatabaseWrapperControlSql(TestDatabaseWrapper):
+    ops_class = TestDatabaseOperationsControlSql
+
+
+test_connection = TestDatabaseWrapper({}, DEFAULT_DB_ALIAS)
+test_control_connection = TestDatabaseWrapperControlSql({}, DEFAULT_DB_ALIAS)


### PR DESCRIPTION
Adds news settings variables

```python
DB_ADAPTER = {
    'DEFAULT_ROLE_NAME': 'role_name', # All tables and sequences will be granted to that role,
    'DEFAULT_OBJECT_PRIVILEGES': [    # All tables will be granted with these privileges (if role was specified)
        'SELECT',
        'INSERT',
        'UPDATE',
        'DELETE',
    ]
}
```

Sequences always are granted only with `SEQUENCE` privilege