### PR TITLE
fix(backends): escape single quotes on column comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - 'develop'
       - 'master'
+      - 'stable/**'
     tags:
       - '*'
 
@@ -21,6 +22,7 @@ on:
     branches:
       - 'develop'
       - 'master'
+      - 'stable/**'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ from django.db import models
 
 class Person(models.Model):
     first_name = models.CharField(max_length=30)
-    last_name = models.CharField(max_length=30)
+    last_name = models.CharField(max_length=30, help_text="It's your last name")
 
     class Meta:
         db_table = 'person'
@@ -151,6 +151,10 @@ alter table example.tb_person
     check (last_name is not null);
 /
 
+comment on column example.tb_person.last_name
+    is 'It''s your last name';
+/
+
 grant select, insert, update, delete
     on example.tb_person
     to rl_example;
@@ -182,7 +186,8 @@ when (new.id is null)
 
 # Release notes
 
-- `v1.0.0` - 16/04/2018 - First release
-- `v1.0.1` - 16/04/2018 - Rename package and fix setup issues
-- `v1.0.2` - 17/04/2018 - Fix documentation preview
-- `v2.0.0` - 01/03/2021 - Recreate the entire schema editor backend with more flexible features
+- `v1.0.0` - Apr 16, 2018 - First release
+- `v1.0.1` - Apr 16, 2018 - Rename package and fix setup issues
+- `v1.0.2` - Apr 17, 2018 - Fix documentation preview
+- `v2.0.0` - Mar 1, 2021 - Recreate the entire schema editor backend with more flexible features
+- `v2.0.1` - Mar 22, 2021 - Escape single quotes on column comments

--- a/db_adapter/db/backends/base/schema.py
+++ b/db_adapter/db/backends/base/schema.py
@@ -221,7 +221,7 @@ class DatabaseSchemaEditor:
         return self.sql_comment_on_column % dict(
             table=self.quote_name(model._meta.db_table),
             column=self.quote_name(field.column),
-            comment=field.help_text,
+            comment=field.help_text.replace("'", "''"),
         )
 
     def _create_index_sql(self, model, fields, suffix='_idx', **kwargs):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name=django-db-adapter
-version=2.0.0.post0
+version=2.0.1
 url=https://github.com/weynelucas/django-db-adapter/
 author=Lucas Weyne
 author_email=weynelucas@gmail.com

--- a/tests/models.py
+++ b/tests/models.py
@@ -29,7 +29,7 @@ class Author(DBAdapterModel):
 
 class Person(DBAdapterModel):
     first_name = models.CharField(max_length=30)
-    last_name = models.CharField(max_length=30)
+    last_name = models.CharField(max_length=30, help_text="It's your last name")
 
     class Meta:
         db_table = 'tbl_person'

--- a/tests/test_backends/test_base/test_schema.py
+++ b/tests/test_backends/test_base/test_schema.py
@@ -10,7 +10,7 @@ from tests.connection import (
     test_control_connection,
     test_format_connetion,
 )
-from tests.models import Article, Author, Post, Square, Tag
+from tests.models import Article, Author, Person, Post, Square, Tag
 
 
 def enforce_str_values(data: dict) -> dict:
@@ -211,6 +211,24 @@ class SqlColumnTests(TestCase):
             [
                 'COMMENT ON COLUMN tbl_tag.description '
                 "IS 'Optional description for tag'"
+            ],
+        )
+
+    def test_column_sql_escape_single_quote(self):
+        editor = TestDatabaseSchemaEditor(test_connection)
+
+        model = Person
+        field = Person._meta.get_field('last_name')
+        sql, _ = editor.column_sql(model, field)
+
+        self.assertEqual(str(sql), 'NVARCHAR2(30)')
+
+        column_sql = enforce_str_values(editor.deferred_column_sql)
+        self.assertEqual(
+            column_sql['COMMENT'],
+            [
+                'COMMENT ON COLUMN tbl_person.last_name '
+                "IS 'It''s your last name'"
             ],
         )
 


### PR DESCRIPTION
Escape single quotes when generate column comments to prevent SQL errors.

A model like:

```python
class Person(models.Model):
    first_name = models.CharField(max_length=45, help_text="It's your first name")

    class Meta:
        db_table = 'tbl_person'
```

Should create a comment for `first_name` like this:

```sql
COMMENT ON COLUMN ON tbl_person.first_name
    IS 'It''s your first name';
/
```